### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ available to you via the  CloudPassage admin view.
 
 These can be set in various ways, via .bashrc , via inline , etc. 
 ```
-export HALO_KEY_ID = 'xxxxx'
-export HALO_SECRET_KEY  = 'xxxxxxxxxxxx'
-export HALO_HOST = 'api.cloudpassage.com'
+export HALO_KEY_ID='xxxxx'
+export HALO_SECRET_KEY='xxxxxxxxxxxx'
+export HALO_HOST='api.cloudpassage.com'
 ```
 
 Launch locally as :


### PR DESCRIPTION
remove spaces between environment variables and equals sign.

(otherwise .bashrc barfs:
bash: export: `=': not a valid identifier
bash: export: `00bae42a': not a valid identifier
bash: export: `=': not a valid identifier
bash: export: `6ee28dee5abde7a08aa97ab5f97b1272': not a valid identifier
bash: export: `=': not a valid identifier
bash: export: `api.cloudpassage.com': not a valid identifier